### PR TITLE
Fix iPad crash

### DIFF
--- a/Example/CropperExample/CropperExample/ViewController.swift
+++ b/Example/CropperExample/CropperExample/ViewController.swift
@@ -40,7 +40,9 @@ class ViewController: UIViewController {
     @IBAction func takePicturePressed(_ sender: Any) {
         cropper.picker = picker
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        
+        alertController.popoverPresentationController?.sourceView = self.view
+        alertController.popoverPresentationController?.sourceRect = CGRect(origin: self.view.center, size: CGSize.zero)
+
         cropper.cancelButtonText = "Retake"
         
         alertController.addAction(UIAlertAction(title: NSLocalizedString("Camera", comment: ""), style: .default) { _ in


### PR DESCRIPTION
iPad requires popover sourceView and sourceRect or a barButtonItem, otherwise it crashes