### PR TITLE
Fix iPhone X / XS Bug

### DIFF
--- a/UIImageCropper/UIImageCropper.swift
+++ b/UIImageCropper/UIImageCropper.swift
@@ -103,12 +103,9 @@ public class UIImageCropper: UIViewController, UIImagePickerControllerDelegate, 
         bottomView.backgroundColor = UIColor.black.withAlphaComponent(0.7)
         self.view.addSubview(topView)
         self.view.addSubview(bottomView)
-        topView.translatesAutoresizingMaskIntoConstraints = false
-        bottomView.translatesAutoresizingMaskIntoConstraints = false
-        let horizontalTopConst = NSLayoutConstraint.constraints(withVisualFormat: "H:|-(0)-[view]-(0)-|", options: NSLayoutConstraint.FormatOptions(), metrics: nil, views: ["view": topView])
-        let horizontalBottomConst = NSLayoutConstraint.constraints(withVisualFormat: "H:|-(0)-[view]-(0)-|", options: NSLayoutConstraint.FormatOptions(), metrics: nil, views: ["view": bottomView])
-        let verticalConst = NSLayoutConstraint.constraints(withVisualFormat: "V:|-(0)-[top]-(0)-[bottom(70)]-|", options: NSLayoutConstraint.FormatOptions(), metrics: nil, views: ["bottom": bottomView, "top": topView])
-        self.view.addConstraints(horizontalTopConst + horizontalBottomConst + verticalConst)
+        view.addConstraintsWithFormat(format: "H:|[v0]|", views: topView)
+        view.addConstraintsWithFormat(format: "H:|[v0]|", views: bottomView)
+        view.addConstraintsWithFormat(format: "V:|[v0][v1(70)]|", views: topView, bottomView)
 
         // image view
         imageView.contentMode = .scaleAspectFit
@@ -148,9 +145,9 @@ public class UIImageCropper: UIViewController, UIImagePickerControllerDelegate, 
         topView.addSubview(cropView)
         let centerXConst = NSLayoutConstraint(item: cropView, attribute: .centerX, relatedBy: .equal, toItem: topView, attribute: .centerX, multiplier: 1, constant: 0)
         let centerYConst = NSLayoutConstraint(item: cropView, attribute: .centerY, relatedBy: .equal, toItem: topView, attribute: .centerY, multiplier: 1, constant: 0)
-        let widthConst = NSLayoutConstraint(item: cropView, attribute: .width, relatedBy: .equal, toItem: topView, attribute: .width, multiplier: 0.9, constant: 0)
+        let widthConst = NSLayoutConstraint(item: cropView, attribute: .width, relatedBy: .equal, toItem: topView, attribute: .width, multiplier: 1, constant: -20)
         widthConst.priority = .defaultHigh
-        let heightConst = NSLayoutConstraint(item: cropView, attribute: .height, relatedBy: .lessThanOrEqual, toItem: topView, attribute: .height, multiplier: 0.9, constant: 0)
+        let heightConst = NSLayoutConstraint(item: cropView, attribute: .height, relatedBy: .lessThanOrEqual, toItem: topView, attribute: .height, multiplier: 1, constant: -20)
         let ratioConst = NSLayoutConstraint(item: cropView, attribute: .width, relatedBy: .equal, toItem: cropView, attribute: .height, multiplier: cropRatio, constant: 0)
         cropView.addConstraints([ratioConst])
         topView.addConstraints([widthConst, heightConst, centerXConst, centerYConst])


### PR DESCRIPTION
On the iPhone X / XS, the cropView and fadeView were not perfectly on top of each other (offset in y direction) and in addition, the Crop / Retake buttons weren't pinned to the bottom of the screen. This is fixed by the first couple lines.  
I also set the height / width constants not to be proportional to the screen size but fixed since that's what I generally prefer for this situation.

You'll need the following extension for the first few lines to work:
(it's generally a very helpful one)

```
extension UIView {
    func addConstraintsWithFormat(format: String, views: UIView...) {
        var viewDict = [String: AnyObject]()
        for (index, view) in views.enumerated() {
            view.translatesAutoresizingMaskIntoConstraints = false
            let key = "v\(index)"
            viewDict[key] = view
        }
        addConstraints(NSLayoutConstraint.constraints(withVisualFormat: format, options: NSLayoutConstraint.FormatOptions(), metrics: nil, views: viewDict))
    }
}
```

Alternatively, you could use something like this in lines 106-108 (and don't have to use the extension):

```
topView.translatesAutoresizingMaskIntoConstraints = false
bottomView.translatesAutoresizingMaskIntoConstraints = false
[topView.leftAnchor.constraint(equalTo: view.leftAnchor),
topView.rightAnchor.constraint(equalTo: view.rightAnchor),

bottomView.leftAnchor.constraint(equalTo: view.leftAnchor),
bottomView.rightAnchor.constraint(equalTo: view.rightAnchor),

topView.topAnchor.constraint(equalTo: view.topAnchor),
bottomView.topAnchor.constraint(equalTo: topView.bottomAnchor),
bottomView.heightAnchor.constraint(equalToConstant: 70),
bottomView.bottomAnchor.constraint(equalTo: view.bottomAnchor)].forEach({ $0.isActive = true })
```

It will also fix the iPhone X / XS bug.